### PR TITLE
Fix 'Attempt to unlock mutex that was not locked' issue.

### DIFF
--- a/src/history.c
+++ b/src/history.c
@@ -224,12 +224,12 @@ void read_history ()
 			}
       
     }
+		g_mutex_unlock(hist_lock);
 done:
 		g_free(magic);
     /* Close file and reverse the history to normal */
     fclose(history_file);
     history_list = g_list_reverse(history_list);
-		g_mutex_unlock(hist_lock);
   }
 	if(dbg) g_printf("History read done\n");
 }


### PR DESCRIPTION
If no history exists the code jumps to function end where g_mutex_unlock() is called on a mutex that is not locked.
Ref: https://bugs.launchpad.net/ubuntu/+source/parcellite/+bug/1388105