### PR TITLE
Convert manpage to semantic mdoc(7) macros.

### DIFF
--- a/doc/parcellite.1
+++ b/doc/parcellite.1
@@ -1,113 +1,173 @@
-.TH PARCELLITE 1 "August 7 2011"
-.SH NAME
-Parcellite \- Lightweight GTK+ Clipboard Manager
-.SH SYNOPSIS
-.B parcellite
-[\fIOPTION\fR]
-.SH DESCRIPTION
-\fBParcellite\fR is a lightweight GTK+ clipboard manager. This is a stripped down,
-basic\-features\-only clipboard manager with a small memory footprint for those
-who like simplicity.
-
-\fBParcellite\fR features a clipboard CLI. Unrecognized options and the contents
-of your standard input get copied to your clipboard. See \fBCLI EXAMPLES\fR.
-
-.B Look at the tool tips by hovering over each item in the prefrences dialog.
-.SH
-.B OPTIONS
-.TP
-.B \-?\fR, \fB\-\-help
+.Dd May 4, 2019
+.Dt PARCELLITE 1
+.Os
+.Sh NAME
+.Nm parcellite
+.Nd Lightweight GTK+ Clipboard Manager
+.Sh SYNOPSIS
+.Nm parcellite
+.Op Fl \&?cnp
+.Sh DESCRIPTION
+.Nm
+is a lightweight GTK+ clipboard manager.
+This is a stripped down clipboard manager with only basic features,
+and a small memory footprint for those who like simplicity.
+.Pp
+.Nm
+features a clipboard CLI.
+Unrecognized options and the contents of your standard input
+get copied to your clipboard.
+See
+.Sx CLI EXAMPLES .
+.Pp
+.Sy Look at the tooltips by hovering over each item in the preferences dialog.
+.Pp
+By default,
+.Nm
+runs as a daemon.
+In this mode,
+.Nm
+will keep your clipboard and primary contents safe.
+It also displays a status icon (unless
+.Fl n
+is specified) and preferences.
+.Sh OPTIONS
+.Bl -tag -width Ds
+.It Fl \&? , Fl Fl help
 Show help options
-.TP
-Parcellite by default runs as daemon. In this mode \fBParcellite\fR will keep your clipboard
-and primary contents safe.  It also displays the status Icon (depending on -n) and preferences.
-.TP
-.B \-n\fR, \fB\-\-no-icon
+.It Fl n , Fl Fl no-icon
 Do not use status icon
-.TP
-.B \-c\fR, \fB\-\-clipboard
+.It Fl c , Fl Fl clipboard
 Print clipboard contents
-.B \-p\fR, \fB\-\-primary
+.It Fl p , Fl Fl primary
 Print primary contents
-.SH ACTIONS
-\fBParcellite's\fR actions perform commands using the contents of your clipboard. "\fB%s\fR" in the command
-is replaced with the clipboard contents. Use double quotes "\fB%s\fR" to expand env variables like $HOME to /home/your_name
-Use single quotes '%s' to feed your action with env variables without shell expansion. Use %% if you want a literal %. 
-See the man page for gnuC printf (man 2 printf) for more information.
-.SH CLI EXAMPLES
- echo "copied to clipboard" | parcellite
- parcellite "copied to clipboard"
- echo "copied to clipboard" | parcellite \-c
-.SH Hotkeys
- The available hotkey modifiers are <Ctrl>, <Alt> <Shift>, <Release>, <Meta>, <Super>, <Hyper>, <Mod[1\-5]>
-.SH Preferences
+.El
+.Sh ACTIONS
+.Nm Ns 's actions perform commands using the contents of your clipboard.
+.Qq %s
+in the command is replaced with the clipboard contents.
+Use double quotes
+.Qq %s
+to expand environment variables like
+.Ev HOME
+to
+.Pa /home/your_name .
+Use single quotes
+\(aq%s\(aq
+to feed your action with environment variables without shell expansion.
+Use %% if you want a literal %.
+See
+.Xr printf 3
+for more information.
+.Sh CLI EXAMPLES
+.D1 echo Qo copied to clipboard Qc | parcellite
+.D1 parcellite Qo copied to clipboard Qc
+.D1 echo Qo copied to clipboard Qc | parcellite -c
+.Sh Hotkeys
+The available hotkey modifiers are
+.Ic <Ctrl> , <Alt> <Shift> , <Release> , <Meta> , <Super> , <Hyper> ,
+.Ic <Mod[1\(en5]>
+.Sh Preferences
 Right-click on the parcellite icon in the systray to access the preferences.
-
-.SH Behavior Tab
-.TP 
-.B Clipboards 
+.Sh Behavior Tab
+.Ss Clipboards
 generally checking all these boxes is appropriate.
-.TP 
-.B History 
- Check 'Save history' to save history on close.
- 'Position history' - Set the location where history appears. If unchecked, appears where the mouse is.
- 'X' - X location in pixels. 0 is top of screen.
- 'Y' - Y location in pixels. 0 is left of screen.
-  
- 'Max Data Size (MB)' - Set Maximum amount of data to copy for each entry in MBytes. 0 is no limit.
-.TP
-.B Miscellaneous
- 'Search As You Type' - If checked, does a search-as-you-type. Turns red if not found. Goes to top (Alt-E) line when no chars are entered for search
-  
- 'Case Sensitive Search' - If checked, does case sensitive search.
-
- 'Ignore Whitespace Only' - If checked, will ignore any clipboard additions that contain only whitespace.
-
- 'Trim Whitespace' - If checked, will trim whitespace from beginning and end of entry.
-
- 'Trim Newlines' - If checked, will replace newlines with spaces.
-
-.SH Display Tab
-.TP 
- 'Show in Single line' does nothing.
-.TP 
- 'Show in reverse order' reverses the history so the first entry is last and the last is first.
-
-.TP
- 'Persistent History' Adds a list that is permanent and never goes away.
-.TP
- 'Persistent As Separate List' Enables the persistent history hotkey, and the persistent history will appear with this key.
-.TP
- 'Persistent On Top' If the above option is checked, this has no effect. Otherwise, if this option is checked the Persistent History will appear on the top of the list. Unchecked, it appears on the bottom.
-.TP
- 'Paste All Entry Delimiter' Delimiter to denote start of a history entry.
-.TP
- 'Alternate Non-printing Display' If checked, displays tabs, newlines, and spaces with alternate characters.
-.TP 
- 'Omit items' refers to omitting characters that don't fit in the history window width. This is for display only.
-.TP
- 'Multiuser' If checked, enables checking for multiple users.
-.TP
- 'Parcellite Icon Name' Sets the name of the Parcellite icon. This name is used by gnome, which usually looks in /usr/share/pixmaps. See the Open Desktop Spec for more details.
-
-.SH History Dialog Behavior
-.TP
+.Ss History
+.Bl -tag -width Ds
+.It Save history
+Save history on close.
+.It Position history
+Set the location where history appears.
+If unchecked, appears where the mouse is.
+.It X
+X location in pixels.
+0 is top of screen.
+.It Y
+Y location in pixels.
+0 is left of screen.
+.It Max Data Size (MB)
+Set Maximum amount of data to copy for each entry in MBytes.
+0 is no limit.
+.El
+.Ss Miscellaneous
+.Bl -tag -width Ds
+.It Search As You Type
+If checked, does a search-as-you-type.
+Turns red if not found.
+Goes to top (Alt-E) line when no chars are entered for search
+.It Case Sensitive Search
+If checked, does case sensitive search.
+.It Ignore Whitespace Only
+If checked, will ignore any clipboard additions that contain only whitespace.
+.It Trim Whitespace
+If checked, will trim whitespace from beginning and end of entry.
+.It Trim Newlines
+If checked, will replace newlines with spaces.
+.El
+.Sh Display Tab
+.Bl -tag -width Ds
+.It Show in Single line
+does nothing.
+.It Show in reverse order
+reverses the history so the first entry is last and the last is first.
+.It Persistent History
+Adds a list that is permanent and never goes away.
+.It Persistent As Separate List
+Enables the persistent history hotkey,
+and the persistent history will appear with this key.
+.It Persistent On Top
+If the above option is checked, this has no effect.
+Otherwise, if this option is checked,
+the Persistent History will appear on the top of the list.
+Unchecked, it appears on the bottom.
+.It Paste All Entry Delimiter
+Delimiter to denote start of a history entry.
+.It Alternate Non-printing Display
+If checked, displays tabs, newlines, and spaces with alternate characters.
+.It Omit items
+refers to omitting characters that don't fit in the history window width.
+This is for display only.
+.It Multiuser
+If checked, enables checking for multiple users.
+.It Parcellite Icon Name
+Sets the name of the Parcellite icon.
+This name is used by gnome, which usually looks in
+.Pa /usr/share/pixmaps .
+See the Open Desktop Spec for more details.
+.El
+.Sh History Dialog Behavior
 Use the Ctrl or Shift key in conjunction with right-click.
-.TP
-If you hold Ctrl, then it toggles the delete on a single item. 
-.TP
-If you hold Shift while holding down right-click (this is like a right-drag), then it toggles each item as it enters the item.
-.TP
+.Pp
+If you hold Ctrl, then it toggles the delete on a single item.
+.Pp
+If you hold Shift while holding down right-click (this is like a right-drag),
+then it toggles each item as it enters the item.
+.Pp
 To complete the delete, hit enter.
-.SH SEE ALSO
-.PP
-Website: http://parcellite.sourceforge.net
-.SH AUTHOR
-Written by Gilberto "Xyhthyx" Miralla <xyhthyx@gmail.com>. Gilberto is no longer maintaining the project. 'Rickyrockrat' is his replacement.
-.SH BUGS
-Please include your ~/.config/parcellite/parcelliterc file when filing a bug.  This will give me your preferences.
- Please report any bugs to the bug tracker via this web page:
- http://sourceforge.net/projects/parcellite/support
- Click on 'Bugs' under 'Project Trackers' to file a bug if you are registered with Source Forge. If not, email rickyrockrat
-(rickyrockrat at users.sourceforge.net), or click the 'project administers' in the link above.
-
+.Sh SEE ALSO
+.Lk http://parcellite.sourceforge.net
+.Sh AUTHORS
+.An -nosplit
+Written by
+.An Gilberto Do Xyhthyx Dc Miralla Aq Mt <xyhthyx@gmail.com .
+Gilberto is no longer maintaining the project.
+.An Rickyrockrat
+is his replacement.
+.Sh BUGS
+Please include your
+.Pa ~/.config/parcellite/parcelliterc
+file when filing a bug.
+This will give me your preferences.
+.Pp
+Please report any bugs to the bug tracker via
+.Lk https://sourceforge.net/projects/parcellite/support SourceForge
+Click on
+.Dq Bugs
+under
+.Dq Project Trackers
+to file a bug if you are registered with SourceForge.
+If not, email rickyrockrat
+.Pq Mt rickyrockrat@users.sourceforge.net ,
+or click the
+.Dq project administrators
+in the link above.


### PR DESCRIPTION
mdoc is a semantic format supported out of the box by all the major manpage formatters (groff and mandoc) on Linux and BSD. The semantics allow for better searching and indexing capabilities than old‐style manpages. The format is a drop‐in replacement.