### PR TITLE
Fix faults in incremental builds

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,3 +1,4 @@
+CFLAGS=-MD
 AM_CFLAGS = -I$(top_srcdir) -DPARCELLITELOCALEDIR=\""$(parcellitelocaledir)"\"
 INCLUDES = $(GTK_CFLAGS) $(APPINDICATOR_CFLAGS)
 LDADD = $(GTK_LIBS) $(APPINDICATOR_LIBS) -lX11 -lgdk-x11-2.0 -lpango-1.0 -lgobject-2.0 -lglib-2.0
@@ -5,6 +6,8 @@ LDADD = $(GTK_LIBS) $(APPINDICATOR_LIBS) -lX11 -lgdk-x11-2.0 -lpango-1.0 -lgobje
 bin_PROGRAMS = parcellite
 
 DISTCLEANFILES = *.bak *.log *~ .deps/*.P
+
+OBJS = *.o
 
 parcellite_SOURCES = main.c main.h \
                      utils.c utils.h \
@@ -20,3 +23,5 @@ $(top_srcdir)/config.h: $(parcellite_SOURCES)
 	GO=$$(grep -c svnversion $(top_srcdir)/configure.ac); if [ "0" != "$$GO" ]; then \
 	VER=$$($(top_srcdir)/svnversion.sh); sed -i "s#\(.*\)svn.*\".*#\1$$VER\"#" $(top_srcdir)/config.h; fi
 	
+# Pull-in dependencies generated with -MD
+-include $(OBJS:.o=.d)


### PR DESCRIPTION
Hello

This commit fixes some bugs regarding the incremental builds of this project.
In particular, running `make` does not trigger the build, even if there are updates in the dependent header files.

The fix uses the `-MD` compiler flag to track dependencies automatically.