### PR TITLE
Fix man page

### DIFF
--- a/doc/parcellite.1
+++ b/doc/parcellite.1
@@ -27,6 +27,7 @@ Do not use status icon
 .TP
 .B \-c\fR, \fB\-\-clipboard
 Print clipboard contents
+.TP
 .B \-p\fR, \fB\-\-primary
 Print primary contents
 .SH ACTIONS


### PR DESCRIPTION
The `-p` option in man page has missing `.TP`, and is printed like following.

```
       -n, --no-icon
              Do not use status icon

       -c, --clipboard
              Print clipboard contents -p, --primary Print primary contents

```