### PR TITLE
remove hardcoded paths from Makefiles

### DIFF
--- a/data/Makefile
+++ b/data/Makefile
@@ -25,16 +25,16 @@ top_srcdir = ..
 srcdir:=.
 
 # po dir
-INSTALL = /usr/bin/install -c
+INSTALL = $(shell which install) -c
 INSTALL_DATA = ${INSTALL} -m 644
-GMSGFMT = /usr/bin/msgfmt
-MSGFMT = /usr/bin/msgfmt
-XGETTEXT = /usr/bin/xgettext
-INTLTOOL_UPDATE = /usr/bin/intltool-update
-INTLTOOL_EXTRACT = /usr/bin/intltool-extract
+GMSGFMT = $(shell which msgfmt)
+MSGFMT = $(GMSFMT)
+XGETTEXT = $(shell which xgettext)
+INTLTOOL_UPDATE = $(shell which intltool-update)
+INTLTOOL_EXTRACT = $(shell which intltool-extract)
 MSGMERGE = INTLTOOL_EXTRACT="$(INTLTOOL_EXTRACT)" XGETTEXT="$(XGETTEXT)" srcdir=$(srcdir) $(INTLTOOL_UPDATE) --gettext-package $(GETTEXT_PACKAGE) --dist
 GENPOT   = INTLTOOL_EXTRACT="$(INTLTOOL_EXTRACT)" XGETTEXT="$(XGETTEXT)" srcdir=$(srcdir) $(INTLTOOL_UPDATE) --gettext-package $(GETTEXT_PACKAGE) --pot
-INTLTOOL_MERGE = /usr/bin/intltool-merge
+INTLTOOL_MERGE = $(shell which intltool-merge)
 
 
 # installable items

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -22,11 +22,12 @@ top_srcdir = ..
 srcdir:=.
 
 # po dir
-INSTALL = /usr/bin/install -c
+WINST=$(shell which install)
+INSTALL = $(WINST) -c
 INSTALL_DATA = ${INSTALL} -m 644
-GMSGFMT = /usr/bin/msgfmt
-MSGFMT = /usr/bin/msgfmt
-XGETTEXT = /usr/bin/xgettext
+GMSGFMT = $(shell which msgfmt)
+MSGFMT = $(GMSGFMT)
+XGETTEXT = $(shell which xgettext)
 
 all: 
 

--- a/po/Makefile
+++ b/po/Makefile
@@ -20,13 +20,14 @@ localedir = $(INSTDIR)/share/locale
 srcdir:=.
 
 # po dir
-INSTALL = /usr/bin/install -c
+WINST=$(shell which install)
+INSTALL = $(WINST) -c
 INSTALL_DATA = ${INSTALL} -m 644
-GMSGFMT = /usr/bin/msgfmt
-MSGFMT = /usr/bin/msgfmt
-XGETTEXT = /usr/bin/xgettext
-INTLTOOL_UPDATE = /usr/bin/intltool-update
-INTLTOOL_EXTRACT = /usr/bin/intltool-extract
+GMSGFMT = $(shell which msgfmt)
+MSGFMT = $(GMSGFMT)
+XGETTEXT = $(shell which xgettext)
+INTLTOOL_UPDATE = $(shell which intltool-update)
+INTLTOOL_EXTRACT = $(shell which intltool-extract)
 MSGMERGE = INTLTOOL_EXTRACT="$(INTLTOOL_EXTRACT)" XGETTEXT="$(XGETTEXT)" srcdir=$(srcdir) $(INTLTOOL_UPDATE) --gettext-package $(GETTEXT_PACKAGE) --dist
 GENPOT   = INTLTOOL_EXTRACT="$(INTLTOOL_EXTRACT)" XGETTEXT="$(XGETTEXT)" srcdir=$(srcdir) $(INTLTOOL_UPDATE) --gettext-package $(GETTEXT_PACKAGE) --pot
 

--- a/simple.common
+++ b/simple.common
@@ -6,9 +6,7 @@ LIBS=$(GTKL) $(XL) $(FONTL) $(FREEL) $(APPI)
 APPI=$(shell $(PRFX)/appsuck.sh lib)
 
 
-TOOLS=intltool-update intltool-extract intltool-merge pkg-config
-
-
+TOOLS=intltool-update intltool-extract intltool-merge pkg-config msgfmt xgettext 
 
 .PHONY: check_dep
 check_dep:

--- a/simple.common
+++ b/simple.common
@@ -12,10 +12,10 @@ TOOLS=intltool-update intltool-extract intltool-merge pkg-config msgfmt xgettext
 check_dep:
 	@if [ -n "$(BUILDCONFIG)" ]; then $(PRFX)/appsuck.sh config; fi
 	@echo "Checking for $(TOOLS)"
-	@for t in $(TOOLS); do	echo -n "Checking for $$t.. "; t=$$(which $$t); \
-	if [ $$? -ne 0 ]; then echo "Missing $$t"; exit 1; else v=$$($$t --version); \
-	i=$$(echo "$$v"|grep $$t|sed 's!.* !!'); if [ -n "$$i" ]; then v="$$i"; fi; \
-	echo "$$t 'V=$$v' OK"; fi; \
+	@for t in $(TOOLS); do	echo -n "Checking for $$t.. "; ft=$$(which $$t); \
+	if [ $$? -ne 0 ]; then echo "Missing $$t"; exit 1; else v=$$($$ft --version); \
+	i=$$(echo "$$v"|grep "$$t"|sed 's!.* !!'); if [ -n "$$i" ]; then v="$$i"; fi; \
+	echo "$$ft 'V=$$v' OK"; fi; \
 	done
 	@echo "    Need gtk+-2.0 x11 fontconfig and freetype2"
 	@echo -n "Checking for gtk.. "
@@ -27,4 +27,4 @@ check_dep:
 	@echo -n "Checking for freetype.. "
 	@if [ -z "$(FREEL)" ]; then echo "No freetype2 libs"; exit 1; else echo OK; fi
 	@echo -n "Checking for a appindicator.. "
-	@if [ -z "$(APPI)" ]; then echo "  appindictor not found"; fi
+	@if [ -z "$(APPI)" ]; then echo "  appindictor not found..thankfully."; fi

--- a/simple.common
+++ b/simple.common
@@ -14,7 +14,7 @@ check_dep:
 	@echo "Checking for $(TOOLS)"
 	@for t in $(TOOLS); do	echo -n "Checking for $$t.. "; t=$$(which $$t); \
 	if [ $$? -ne 0 ]; then echo "Missing $$t"; exit 1; else v=$$($$t --version); \
-	i=$$(echo "$$v"|grep intlt|sed 's!.* !!'); if [ -n "$$i" ]; then v="$$i"; fi; \
+	i=$$(echo "$$v"|grep $$t|sed 's!.* !!'); if [ -n "$$i" ]; then v="$$i"; fi; \
 	echo "$$t 'V=$$v' OK"; fi; \
 	done
 	@echo "    Need gtk+-2.0 x11 fontconfig and freetype2"


### PR DESCRIPTION
This will make it easier to compile parcellite on systems that keep build tools in non-standard directories.