### PR TITLE
Fix for gcc-15: extraenous parameter to parcellite_init()

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -2519,7 +2519,7 @@ int main(int argc, char *argv[])
 	}	
   
   /* Init Parcellite */
-  parcellite_init(mode);
+  parcellite_init();
   /*g_printf("Start main loop\n"); */
   /* Run GTK+ loop */
   gtk_main();


### PR DESCRIPTION
Fixes compilation error:
  main.c:2522:3: error: too many arguments to function 'parcellite_init'

Since commit 6bf0cc8e (2013-01-20), parcellite_init() has been called with a 'mode' parameter, but the function definition was never updated to accept it. This caused compilation failures with stricter compilers like GCC 15, (though it has been fine thus far with GCC 14).

The parameter is actually unnecessary since parcellite_init() is only ever called when mode == PROG_MODE_DAEMON (client mode exits before reaching this call), and unused (since it's not even accepted as a formal parameter).